### PR TITLE
[PROD-1224] Fix deployment pipeline #26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run:
           name: deploy
           command: |
-            ecs deploy --tag $TAG platform $SERVICE
+            ecs deploy --tag $TAG $CLUSTER $SERVICE
 
 
 workflows:

--- a/terraform/modules/standard_application_fargate/ecs_task.tf
+++ b/terraform/modules/standard_application_fargate/ecs_task.tf
@@ -15,7 +15,7 @@ resource "aws_ecs_task_definition" "this" {
   container_definitions = data.template_file.container_definitions_file.rendered
 
   execution_role_arn = aws_iam_role.task_execution.arn
-  task_role_arn      = aws_iam_role.task_role.arn
+  task_role_arn      = aws_iam_role.task.arn
 
   requires_compatibilities = ["FARGATE"]
   cpu                      = "256"


### PR DESCRIPTION
## Why
- We committed some wrong configurations on `master` branch, and they are broken our pipeline

## What
- Fix `ecs deploy` command on the deployment pipeline
- Fix a terraform resource naming 

## Jira
- https://creditas.atlassian.net/browse/PROD-1224

## Terraform Plan
```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
Releasing state lock. This may tak
```